### PR TITLE
Support multiple reasons for rejected privileges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,8 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Remove lock for PHP 8
-        if: matrix.php-version == '8.0'
+      - name: Remove lock for newer PHP
+        if: matrix.php-version != '7.2'
         run: rm composer.lock && composer require symfony/cache
 
       - name: Install dependencies
@@ -119,6 +119,9 @@ jobs:
           path: ~/.cache/composer
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
+
+      - name: Remove lock for newer PHP
+        run: rm composer.lock && composer require symfony/cache
 
       - name: Install dependencies
         run: composer install

--- a/src/Acl/Acl.php
+++ b/src/Acl/Acl.php
@@ -18,9 +18,9 @@ class Acl extends \Laminas\Permissions\Acl\Acl
     private $message;
 
     /**
-     * @var null|string
+     * @var string[]
      */
-    private $reason;
+    private $reasons = [];
 
     protected function createModelResource(string $class): ModelResource
     {
@@ -39,7 +39,7 @@ class Acl extends \Laminas\Permissions\Acl\Acl
     {
         $resource = new ModelResource($this->getClass($model), $model);
         $role = $this->getCurrentRole();
-        $this->reason = null;
+        $this->reasons = [];
 
         $isAllowed = $this->isAllowed($role, $resource, $privilege);
 
@@ -58,7 +58,7 @@ class Acl extends \Laminas\Permissions\Acl\Acl
      */
     public function reject(string $reason): bool
     {
-        $this->reason = $reason;
+        $this->reasons[] = $reason;
 
         return false;
     }
@@ -92,8 +92,14 @@ class Acl extends \Laminas\Permissions\Acl\Acl
 
         $message = "$userName with role $role is not allowed on resource \"$resource\" with privilege \"$privilege\"";
 
-        if ($this->reason) {
-            $message .= ' because ' . $this->reason;
+        $count = count($this->reasons);
+        if ($count === 1) {
+            $message .= ' because ' . $this->reasons[0];
+        } elseif ($count) {
+            $list = array_map(function ($reason) {
+                return '- ' . $reason;
+            }, $this->reasons);
+            $message .= ' because:' . PHP_EOL . PHP_EOL . implode(PHP_EOL, $list);
         }
 
         return $message;

--- a/tests/Acl/AclTest.php
+++ b/tests/Acl/AclTest.php
@@ -59,6 +59,9 @@ final class AclTest extends TestCase
         self::assertSame('Non-logged user with role anonymous is not allowed on resource "User#null" with privilege "update"', $acl->getLastDenialMessage());
     }
 
+    /**
+     * @requires PHP 7.3
+     */
     public function testMultipleReasons(): void
     {
         $acl = new class() extends Acl {


### PR DESCRIPTION
Because multiple assertions, across mutliple allow rules, might be
tested, then it is possible that there are mutliple reasons to why
the privilege was denied.